### PR TITLE
stepselection: detect and bail on nil buildReport

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -254,6 +254,9 @@ func (s *stepSkipper) Close() {
 
 func newStepSkipper(logFile string, upFile string) (*stepSkipper, error) {
 	buildReport, err := builddata.OpenFile(logFile)
+	if err != nil {
+		return nil, err
+	}
 	updatedNodes, err := updatedNodes(upFile)
 	if err != nil {
 		return nil, err

--- a/stepselection/stepselection.go
+++ b/stepselection/stepselection.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -93,6 +94,9 @@ func NewDependencyGraph(buildReport io.Reader) (*DependencyGraph, error) {
 		fileWriters: map[string][]*step{},
 	}
 	start := time.Now()
+	if buildReport == nil {
+		return nil, errors.New("invalid build report")
+	}
 	scanner := bufio.NewScanner(buildReport)
 	for scanner.Scan() {
 		bog := &BuildLog{}


### PR DESCRIPTION
Otherwise, doing Scan() on a bufio.Scanner created with a nil Reader
apparently panics.

This is only fixing the symptom, I have no idea whether a buildReport is
expected to be sometimes nil or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yourbase/skipper/10)
<!-- Reviewable:end -->
